### PR TITLE
feat: allow to pass options to create index

### DIFF
--- a/src/gatsby-node.js
+++ b/src/gatsby-node.js
@@ -14,8 +14,8 @@ const { generateTypeName, generateNodeId } = createNodeHelpers({
 
 // Returns an exported FlexSearch index using the provided documents, fields,
 // and ref.
-const createFlexSearchIndexExport = ({ documents, ref }) => {
-  const index = FlexSearch.create()
+const createFlexSearchIndexExport = ({ documents, ref, options }) => {
+  const index = FlexSearch.create(options || {})
 
   documents.forEach(doc => index.add(doc[ref], JSON.stringify(doc)))
 
@@ -57,7 +57,7 @@ const createIndexExport = ({ reporter, name, engine, ...args }) => {
 // values will be used in createResolvers.
 export const createPages = async (
   { graphql, cache, reporter },
-  { name, ref = 'id', store: storeFields, query, normalizer, engine },
+  { name, ref = 'id', store: storeFields, query, normalizer, engine, options },
 ) => {
   const result = await graphql(query)
   if (result.errors) throw R.head(result.errors)
@@ -81,6 +81,7 @@ export const createPages = async (
     documents,
     fields,
     ref,
+    options
   })
 
   // Default to all fields if storeFields is not provided


### PR DESCRIPTION
Currently the FlexSearch index is created via `FlexSearch.create()`, which doesn't allow to customise how the index is generated.
The FlexSearch [`create`](https://github.com/nextapps-de/flexsearch#flexsearch.create) function allows an options object to be passed, which allow customisation. 
Adding an `options` object parameter to the `createPages` function allows to customise the index creation from the `gatsby-plugin-local-search` config.