### PR TITLE
feat: safely set default normalizer fields

### DIFF
--- a/src/gatsby-node.js
+++ b/src/gatsby-node.js
@@ -84,7 +84,7 @@ export const createPages = async (gatsbyContext, pluginOptions) => {
     )
 
   // Default set of fields to index.
-  const normalizerFields = Object.keys(documents[0])
+  const normalizerFields = documents.length > 0 ? Object.keys(documents[0]) : []
 
   const index = createIndexExport({
     reporter,


### PR DESCRIPTION
This PR changes the default `normalizerFields` to be safely set by checking if `documents` has at least one document available. Prevents breaking builds when the result of a GraphQL search query returns no nodes.