### PR TITLE
Exclude field names from flexsearch index

### DIFF
--- a/src/gatsby-node.ts
+++ b/src/gatsby-node.ts
@@ -31,12 +31,12 @@ const createFlexSearchIndexExport = (
   const index = FlexSearch.create<IndexableDocument>(engineOptions)
 
   documents.forEach((doc) => {
-    const serializedDoc = JSON.stringify(
+    const docFieldValues = Object.values(
       indexFields ? pick(doc, indexFields) : doc,
     )
     // Using "as number" due to FlexSearch's types, but it could technically be
     // a string as well.
-    index.add(doc[ref] as number, serializedDoc)
+    index.add(doc[ref] as number, JSON.stringify(docFieldValues))
   })
 
   return index.export()


### PR DESCRIPTION
Currently field names are included in the index when using flexsearch. If, for example, you use a `title` field, the index will include the word 'title' (and its base variations) as well. So searching for 'title' would return every single document, because every document had 'title' included in the stringified content.

The change in this PR prevents this by just stringifying the document field values, instead of the entire document.